### PR TITLE
WIP: Update the lxdclient code to be compatible with 2.0.0beta3.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -38,7 +38,7 @@ github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:5
 github.com/juju/utils	git	6a56fe5cf0ae360cb6bf19f287289eaf9e28aea9	2015-12-11T00:56:23Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
-github.com/lxc/lxd	git	487a7abedeb68506040da9283dd099626ba63026	2015-10-27T22:33:42Z
+github.com/lxc/lxd	git	ada4083375681985ce990bf82569b3665043f2db	2016-02-18T03:41:21Z
 github.com/mattn/go-colorable	git	40e4aedc8fabf8c23e040057540867186712faa5	2015-06-25T15:46:42Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/mattn/go-isatty	git	d6aaa2f596ae91a0a58d8e7f2c79670991468e4f	2015-11-07T15:36:48Z

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -41,7 +41,9 @@ func (inst *environInstance) Status() string {
 // Addresses implements instance.Instance.
 func (inst *environInstance) Addresses() ([]network.Address, error) {
 	// TODO(ericsnow) This may need to be more dynamic.
-	return inst.raw.Addresses, nil
+	// return inst.raw.Addresses, nil
+	/// XXX: jam fix this
+	return nil, nil
 }
 
 func findInst(id instance.Id, instances []instance.Instance) instance.Instance {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -237,7 +237,8 @@ func (s *BaseSuiteUnpatched) NewRawInstance(c *gc.C, name string) *lxdclient.Ins
 		Status:    lxdclient.StatusRunning,
 		Hardware:  *s.Hardware,
 		Metadata:  s.Metadata,
-		Addresses: s.Addresses,
+		// XXX: jam
+		// Addresses: s.Addresses,
 	}
 	instanceSpec := lxdclient.InstanceSpec{
 		Name:      name,

--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -14,7 +14,7 @@ import (
 )
 
 type rawImageClient interface {
-	ListAliases() ([]shared.ImageAlias, error)
+	ListAliases() (shared.ImageAliases, error)
 }
 
 type imageClient struct {

--- a/tools/lxdclient/client_raw.go
+++ b/tools/lxdclient/client_raw.go
@@ -71,7 +71,7 @@ type rawImageMethods interface {
 
 type rawAliasMethods interface {
 	// info
-	ListAliases() ([]shared.ImageAlias, error)
+	ListAliases() (shared.ImageAliases, error)
 	IsAlias(alias string) (bool, error)
 
 	// alias data (upload, download, destroy)
@@ -84,12 +84,12 @@ type rawContainerMethods interface {
 	// info/meta
 	ListContainers() ([]shared.ContainerInfo, error)
 	//Rename(name string, newName string) (*lxd.Response, error)
-	ContainerStatus(name string) (*shared.ContainerState, error)
+	ContainerState(name string) (*shared.ContainerState, error)
 
 	// container data (create, actions, destroy)
 	Init(name string, imgremote string, image string, profiles *[]string, config map[string]string, ephem bool) (*lxd.Response, error)
 	LocalCopy(source string, name string, config map[string]string, profiles []string, ephemeral bool) (*lxd.Response, error)
-	MigrateFrom(name string, operation string, secrets map[string]string, architecture int, config map[string]string, devices shared.Devices, profiles []string, baseImage string, ephemeral bool) (*lxd.Response, error)
+	MigrateFrom(name string, operation string, certificate string, secrets map[string]string, architecture int, config map[string]string, devices shared.Devices, profiles []string, baseImage string, ephemeral bool) (*lxd.Response, error)
 	Action(name string, action shared.ContainerAction, timeout int, force bool) (*lxd.Response, error)
 	Delete(name string) (*lxd.Response, error)
 
@@ -103,7 +103,7 @@ type rawContainerMethods interface {
 	// config
 	GetContainerConfig(container string) ([]string, error)
 	SetContainerConfig(container, key, value string) error
-	UpdateContainerConfig(container string, st shared.BriefContainerState) error
+	UpdateContainerConfig(container string, st shared.BriefContainerInfo) error
 
 	// devices
 	ContainerListDevices(container string) ([]string, error)
@@ -113,7 +113,7 @@ type rawContainerMethods interface {
 	// snapshots
 	RestoreSnapshot(container string, snapshotName string, stateful bool) (*lxd.Response, error)
 	Snapshot(container string, snapshotName string, stateful bool) (*lxd.Response, error)
-	ListSnapshots(container string) ([]shared.SnapshotState, error)
+	ListSnapshots(container string) ([]shared.SnapshotInfo, error)
 }
 
 type rawProfileMethods interface {

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -7,15 +7,12 @@ package lxdclient
 
 import (
 	"fmt"
-	/// XXX: jam 2016-02-22 "net"
 	"strings"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/arch"
 	"github.com/lxc/lxd/shared"
-
-	"github.com/juju/juju/network"
 )
 
 // Constants related to user metadata.
@@ -140,9 +137,6 @@ type InstanceSummary struct {
 
 	// Metadata is the instance metadata.
 	Metadata map[string]string
-
-	// Addresses
-	Addresses []network.Address
 }
 
 func newInstanceSummary(info *shared.ContainerInfo) InstanceSummary {
@@ -159,26 +153,6 @@ func newInstanceSummary(info *shared.ContainerInfo) InstanceSummary {
 		fmt.Sscanf(raw, "%d", &mem)
 	}
 
-	var addrs []network.Address
-	/// XXX: jam 2016-02-22 For now we can't track IPs. The problem is
-	/// that IPs are only on the ContainerState object, but things like
-	/// Architecture and Name are only on the ContainerInfo object.
-	/// ListContainers returns an array of the latter, but we'd have to do
-	/// an extra API request per container to get objects of the former.
-	/// certainly can, but I'd like to know that we need to first.
-	/// for _, info := range info.Status.Ips {
-	/// 	addr := network.NewAddress(info.Address)
-
-	/// 	// Ignore loopback devices.
-	/// 	// TODO(ericsnow) Move the loopback test to a network.Address method?
-	/// 	ip := net.ParseIP(addr.Value)
-	/// 	if ip != nil && ip.IsLoopback() {
-	/// 		continue
-	/// 	}
-
-	/// 	addrs = append(addrs, addr)
-	/// }
-
 	// TODO(ericsnow) Factor this out into a function.
 	statusStr := info.Status
 	for status, code := range allStatuses {
@@ -194,7 +168,6 @@ func newInstanceSummary(info *shared.ContainerInfo) InstanceSummary {
 		Name:      info.Name,
 		Status:    statusStr,
 		Metadata:  metadata,
-		Addresses: addrs,
 		Hardware: InstanceHardware{
 			Architecture: archStr,
 			NumCores:     numCores,

--- a/tools/lxdclient/testing_test.go
+++ b/tools/lxdclient/testing_test.go
@@ -72,8 +72,8 @@ func (s *stubClient) CertificateAdd(cert *x509.Certificate, name string) error {
 	return nil
 }
 
-func (s *stubClient) ContainerStatus(name string) (*shared.ContainerState, error) {
-	s.stub.AddCall("ContainerStatus", name)
+func (s *stubClient) ContainerState(name string) (*shared.ContainerState, error) {
+	s.stub.AddCall("ContainerState", name)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Not ready to be landed.

This has a prerequisite of github.com/jameinel/juju lxd-container-type which just merges the latest master into lxd-container-type without actually updating the lxd dependency (which is why the diff is so big).

This patch just updates juju's 'lxdclient' shim to be compatible with lxd's 2.0.0.beta3 release. The most notable change is that lxd changed ContainerStatus into ContainerInfo and flattened a bunch of the fields (eg info.State.Status.Status became just info.Status).

The reason this is not ready is because LXD did not flatten the []Ips field, which we need. So we need to figure out if we need to always make a ContainerState() request for every instance.
