### PR TITLE
Add cli version checks and clean up cli test mock. Add api v4 tests.

### DIFF
--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -66,6 +66,7 @@ type ModelManagerAPI interface {
 	ListModels(user string) ([]base.UserModel, error)
 	ListModelsWithInfo(user string) ([]params.ModelInfoResult, error)
 	ModelInfo([]names.ModelTag) ([]params.ModelInfoResult, error)
+	BestAPIVersion() int
 }
 
 // ModelsSysAPI defines the methods on the controller manager API that the
@@ -147,10 +148,18 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	}
 
 	now := time.Now()
+
+	modelmanagerAPI, err := c.getModelManagerAPI()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer modelmanagerAPI.Close()
+
 	var modelInfo []common.ModelInfo
-	if !c.oldAPI {
+	// TODO (anastasiamac 2017-11-6) oldAPI will need to be removed before merging into develop.
+	if !c.oldAPI && modelmanagerAPI.BestAPIVersion() > 3 {
 		// New code path
-		modelInfo, err = c.getNewModelInfo(controllerName, now)
+		modelInfo, err = c.getNewModelInfo(ctx, modelmanagerAPI, controllerName, now)
 		if err != nil {
 			return errors.Annotate(err, "unable to get model details")
 		}
@@ -160,7 +169,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		if c.all {
 			models, err = c.getAllModels()
 		} else {
-			models, err = c.getUserModels()
+			models, err = c.getUserModels(modelmanagerAPI)
 		}
 		if err != nil {
 			return errors.Annotate(err, "cannot list models")
@@ -168,7 +177,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 
 		// TODO(perrito666) 2016-05-02 lp:1558657
 		// And now get the full details of the models.
-		modelInfo, err = c.getModelInfo(controllerName, now, models)
+		modelInfo, err = c.getModelInfo(modelmanagerAPI, controllerName, now, models)
 		if err != nil {
 			return errors.Annotate(err, "cannot get model details")
 		}
@@ -184,7 +193,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 
 	modelSet := ModelSet{Models: modelInfo}
 	current, err := c.ClientStore().CurrentModel(controllerName)
-	if err == nil || errors.IsNotFound(err) {
+	if err == nil {
 		// It is not a problem if we could not get current model -
 		// it could have been destroyed since last time we've used this client.
 		// However, if we do find it, we'd want to mark it in the output.
@@ -204,33 +213,33 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	if err := c.out.Write(ctx, modelSet); err != nil {
 		return err
 	}
-	/// if len(models) == 0 && c.out.Name() == "tabular" {
-	/// 	// When the output is tabular, we inform the user when there
-	/// 	// are no models available, and tell them how to go about
-	/// 	// creating or granting access to them.
-	/// 	fmt.Fprintln(ctx.Stderr, noModelsMessage)
-	/// }
+	if len(modelInfo) == 0 && c.out.Name() == "tabular" {
+		// When the output is tabular, we inform the user when there
+		// are no models available, and tell them how to go about
+		// creating or granting access to them.
+		fmt.Fprintln(ctx.Stderr, noModelsMessage)
+	}
 	return nil
 }
 
-func (c *modelsCommand) getNewModelInfo(controllerName string, now time.Time) ([]common.ModelInfo, error) {
-	client, err := c.getModelManagerAPI()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer client.Close()
+func (c *modelsCommand) getNewModelInfo(ctx *cmd.Context, client ModelManagerAPI, controllerName string, now time.Time) ([]common.ModelInfo, error) {
 	results, err := client.ListModelsWithInfo(c.user)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	info := []common.ModelInfo{}
 	for _, result := range results {
+		// Since we do not want to throw away all results if we have an
+		// an issue with a model, we will display errors in Stderr
+		// and will continue processing the rest.
 		if result.Error != nil {
-			return nil, errors.Trace(result.Error)
+			ctx.Infof(result.Error.Error())
+			continue
 		}
 		model, err := common.ModelInfoFromParams(*result.Result, now)
 		if err != nil {
-			return nil, errors.Trace(err)
+			ctx.Infof(err.Error())
+			continue
 		}
 		model.ControllerName = controllerName
 		info = append(info, model)
@@ -238,13 +247,7 @@ func (c *modelsCommand) getNewModelInfo(controllerName string, now time.Time) ([
 	return info, nil
 }
 
-func (c *modelsCommand) getModelInfo(controllerName string, now time.Time, userModels []base.UserModel) ([]common.ModelInfo, error) {
-	client, err := c.getModelManagerAPI()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer client.Close()
-
+func (c *modelsCommand) getModelInfo(client ModelManagerAPI, controllerName string, now time.Time, userModels []base.UserModel) ([]common.ModelInfo, error) {
 	tags := make([]names.ModelTag, len(userModels))
 	for i, m := range userModels {
 		tags[i] = names.NewModelTag(m.UUID)
@@ -288,12 +291,7 @@ func (c *modelsCommand) getAllModels() ([]base.UserModel, error) {
 	return client.AllModels()
 }
 
-func (c *modelsCommand) getUserModels() ([]base.UserModel, error) {
-	client, err := c.getModelManagerAPI()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer client.Close()
+func (c *modelsCommand) getUserModels(client ModelManagerAPI) ([]base.UserModel, error) {
 	return client.ListModels(c.user)
 }
 

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -64,7 +64,7 @@ See also:
 type ModelManagerAPI interface {
 	Close() error
 	ListModels(user string) ([]base.UserModel, error)
-	ListModelsWithInfo(user string) ([]params.ModelInfoResult, error)
+	ListModelsWithInfo(user names.UserTag) ([]params.ModelInfoResult, error)
 	ModelInfo([]names.ModelTag) ([]params.ModelInfoResult, error)
 	BestAPIVersion() int
 }
@@ -146,6 +146,9 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	if c.user == "" {
 		c.user = accountDetails.User
 	}
+	if !names.IsValidUser(c.user) {
+		return errors.NotValidf("user %q", c.user)
+	}
 
 	now := time.Now()
 
@@ -223,7 +226,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *modelsCommand) getNewModelInfo(ctx *cmd.Context, client ModelManagerAPI, controllerName string, now time.Time) ([]common.ModelInfo, error) {
-	results, err := client.ListModelsWithInfo(c.user)
+	results, err := client.ListModelsWithInfo(names.NewUserTag(c.user))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -4,6 +4,7 @@
 package controller_test
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/juju/cmd"
@@ -72,7 +73,7 @@ func (f *fakeModelMgrAPIClient) AllModels() ([]base.UserModel, error) {
 	return f.convertInfosToUserModels(), nil
 }
 
-func (f *fakeModelMgrAPIClient) ListModelsWithInfo(user string) ([]params.ModelInfoResult, error) {
+func (f *fakeModelMgrAPIClient) ListModelsWithInfo(user names.UserTag) ([]params.ModelInfoResult, error) {
 	f.MethodCall(f, "ListModelsWithInfo", user)
 	if f.err != nil {
 		return nil, f.err
@@ -366,6 +367,12 @@ func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
 func (s *ModelsSuite) TestUnrecognizedArg(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newCommand(), "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+	s.api.CheckNoCalls(c)
+}
+
+func (s *ModelsSuite) TestInvalidUser(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "+bob")
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`user "+bob" not valid`))
 	s.api.CheckNoCalls(c)
 }
 

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -28,98 +30,83 @@ type ModelsSuite struct {
 	store *jujuclient.MemStore
 }
 
+type ModelsSuiteV4 struct {
+	ModelsSuite
+}
+
 var _ = gc.Suite(&ModelsSuite{})
+var _ = gc.Suite(&ModelsSuiteV4{})
 
 type fakeModelMgrAPIClient struct {
-	err          error
-	user         string
-	models       []base.UserModel
-	all          bool
-	inclMachines bool
-	denyAccess   bool
-	infos        []params.ModelInfoResult
+	*gitjujutesting.Stub
+
+	err   error
+	infos []params.ModelInfoResult
+
+	version int
+}
+
+func (f *fakeModelMgrAPIClient) BestAPIVersion() int {
+	f.MethodCall(f, "BestAPIVersion")
+	return f.version
 }
 
 func (f *fakeModelMgrAPIClient) Close() error {
+	f.MethodCall(f, "Close")
 	return nil
 }
 
 func (f *fakeModelMgrAPIClient) ListModels(user string) ([]base.UserModel, error) {
+	f.MethodCall(f, "ListModels", user)
 	if f.err != nil {
 		return nil, f.err
 	}
-
-	f.user = user
-	return f.models, nil
+	return f.convertInfosToUserModels(), nil
 }
 
 func (f *fakeModelMgrAPIClient) AllModels() ([]base.UserModel, error) {
+	f.MethodCall(f, "AllModels")
 	if f.err != nil {
 		return nil, f.err
 	}
-	f.all = true
-	return f.models, nil
+	return f.convertInfosToUserModels(), nil
+}
+
+func (f *fakeModelMgrAPIClient) ListModelsWithInfo(user string) ([]params.ModelInfoResult, error) {
+	f.MethodCall(f, "ListModelsWithInfo", user)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.infos, nil
 }
 
 func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, error) {
+	f.MethodCall(f, "ModelInfo", tags)
 	if f.infos != nil {
 		return f.infos, nil
 	}
-	agentVersion, _ := version.Parse("2.55.5")
 	results := make([]params.ModelInfoResult, len(tags))
 	for i, tag := range tags {
-		for _, model := range f.models {
-			if model.UUID != tag.Id() {
-				continue
+		for _, model := range f.infos {
+			if model.Error == nil {
+				if model.Result.UUID != tag.Id() {
+					continue
+				}
+				results[i] = model
 			}
-			result := &params.ModelInfo{
-				Name:         model.Name,
-				UUID:         model.UUID,
-				OwnerTag:     names.NewUserTag(model.Owner).String(),
-				CloudTag:     "cloud-dummy",
-				Status:       params.EntityStatus{},
-				AgentVersion: &agentVersion,
-			}
-			switch model.Name {
-			case "test-model1":
-				last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
-				result.Status.Status = status.Active
-				if f.user != "" {
-					result.Users = []params.ModelUserInfo{{
-						UserName:       f.user,
-						LastConnection: &last1,
-						Access:         params.ModelReadAccess,
-					}}
-				}
-				if f.inclMachines {
-					one := uint64(1)
-					result.Machines = []params.ModelMachineInfo{
-						{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
-					}
-				}
-			case "test-model2":
-				last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
-				result.Status.Status = status.Active
-				if f.user != "" {
-					result.Users = []params.ModelUserInfo{{
-						UserName:       f.user,
-						LastConnection: &last2,
-						Access:         params.ModelWriteAccess,
-					}}
-				}
-			case "test-model3":
-				if f.denyAccess {
-					results[i].Error = &params.Error{
-						Message: "permission denied",
-						Code:    params.CodeUnauthorized,
-					}
-				}
-				result.Status.Status = status.Destroying
-			}
-			results[i].Result = result
 		}
 	}
 	return results, nil
+}
+
+func (f *fakeModelMgrAPIClient) convertInfosToUserModels() []base.UserModel {
+	models := make([]base.UserModel, len(f.infos))
+	for i, info := range f.infos {
+		if info.Error == nil {
+			models[i] = base.UserModel{UUID: info.Result.UUID}
+		}
+	}
+	return models
 }
 
 func (s *ModelsSuite) SetUpTest(c *gc.C) {
@@ -140,10 +127,7 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 			UUID:  "test-model3-UUID",
 		},
 	}
-	s.api = &fakeModelMgrAPIClient{
-		models: models,
-		user:   "admin",
-	}
+
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "fake"
 	s.store.Controllers["fake"] = jujuclient.ControllerDetails{}
@@ -154,16 +138,37 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 		User:     "admin",
 		Password: "password",
 	}
-}
 
-func (s *ModelsSuite) newCommand() cmd.Command {
-	return controller.NewListModelsCommandForTest(s.api, s.api, s.store)
+	s.api = &fakeModelMgrAPIClient{
+		Stub:    &gitjujutesting.Stub{},
+		version: 3,
+	}
+	s.api.infos = convert(models)
+
+	// Make api results interesting...
+	// 1st model
+	firstModel := s.api.infos[0].Result
+	last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
+	firstModel.Users = []params.ModelUserInfo{{
+		UserName:       "admin",
+		LastConnection: &last1,
+		Access:         params.ModelReadAccess,
+	}}
+	//2nd model
+	secondModel := s.api.infos[1].Result
+	last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
+	secondModel.Users = []params.ModelUserInfo{{
+		UserName:       "admin",
+		LastConnection: &last2,
+		Access:         params.ModelWriteAccess,
+	}}
+	// 3rd model
+	s.api.infos[2].Result.Status.Status = status.Destroying
 }
 
 func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
@@ -172,12 +177,12 @@ func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestModelsYaml(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 models:
 - name: admin/test-model1
@@ -223,20 +228,31 @@ models:
   agent-version: 2.55.5
 current-model: test-model1
 `[1:])
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestModelsJson(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"test-model1"}
 `)
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
+	// Ensure fake api caters to user 'bob'
+	for _, apiInfo := range s.api.infos {
+		if apiInfo.Error == nil {
+			bobs := make([]params.ModelUserInfo, len(apiInfo.Result.Users))
+			for i, u := range apiInfo.Result.Users {
+				u.UserName = "bob"
+				bobs[i] = u
+			}
+			apiInfo.Result.Users = bobs
+		}
+	}
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "bob")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.user, gc.Equals, "bob")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
@@ -245,18 +261,18 @@ func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestAllModels(c *gc.C) {
 	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.all, jc.IsTrue)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"admin/test-model1*           dummy         active      read    2015-03-20\n"+
+		"test-model1*                 dummy         active      read    2015-03-20\n"+
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
@@ -265,6 +281,7 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 		"carlotta/test-model2":        jujuclient.ModelDetails{"test-model2-UUID"},
 		"daiwik@external/test-model3": jujuclient.ModelDetails{"test-model3-UUID"},
 	})
+	s.checkAPICalls(c, "BestAPIVersion", "AllModels", "Close", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
@@ -279,13 +296,17 @@ func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
-	s.api.inclMachines = true
+	one := uint64(1)
+	s.api.infos[0].Result.Machines = []params.ModelMachineInfo{
+		{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
+	}
+
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--uuid")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
@@ -294,13 +315,17 @@ func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 		"carlotta/test-model2         test-model2-UUID  dummy         active             0      -  write   2015-03-01\n"+
 		"daiwik@external/test-model3  test-model3-UUID  dummy         destroying         0      -  -       never connected\n"+
 		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
-	s.api.inclMachines = true
+	one := uint64(1)
+	s.api.infos[0].Result.Machines = []params.ModelMachineInfo{
+		{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
+	}
+
 	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.user, gc.Equals, "admin")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
@@ -309,11 +334,19 @@ func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
 		"carlotta/test-model2         dummy         active             0      -  write   2015-03-01\n"+
 		"daiwik@external/test-model3  dummy         destroying         0      -  -       never connected\n"+
 		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
+// This test is only needed for older api versions as
+// whether the user has an access to a model will be checked on
+// the api side and the model data will not be sent.
 func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
 	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
-	s.api.denyAccess = true
+	s.api.infos[2].Error = &params.Error{
+		Message: "permission denied",
+		Code:    params.CodeUnauthorized,
+	}
+
 	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
@@ -327,31 +360,20 @@ func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
 		"admin/test-model1":    jujuclient.ModelDetails{"test-model1-UUID"},
 		"carlotta/test-model2": jujuclient.ModelDetails{"test-model2-UUID"},
 	})
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
 func (s *ModelsSuite) TestUnrecognizedArg(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newCommand(), "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+	s.api.CheckNoCalls(c)
 }
 
 func (s *ModelsSuite) TestModelsError(c *gc.C) {
 	s.api.err = common.ErrPerm
 	_, err := cmdtesting.RunCommand(c, s.newCommand())
-	c.Assert(err, gc.ErrorMatches, "cannot list models: permission denied")
-}
-
-func createBasicModelInfo() *params.ModelInfo {
-	agentVersion, _ := version.Parse("2.55.5")
-	return &params.ModelInfo{
-		Name:           "basic-model",
-		UUID:           testing.ModelTag.Id(),
-		ControllerUUID: testing.ControllerTag.Id(),
-		OwnerTag:       names.NewUserTag("owner").String(),
-		Life:           params.Dead,
-		CloudTag:       names.NewCloudTag("altostratus").String(),
-		CloudRegion:    "mid-level",
-		AgentVersion:   &agentVersion,
-	}
+	c.Assert(err, gc.ErrorMatches, ".*: permission denied")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "Close")
 }
 
 func (s *ModelsSuite) TestWithIncompleteModels(c *gc.C) {
@@ -389,6 +411,24 @@ owner/basic-model  altostratus/mid-level  -              0      -  admin   never
 owner/basic-model  altostratus/mid-level  -              2      -  -       never connected
 
 `[1:])
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *ModelsSuite) TestListModelsWithAgent(c *gc.C) {
+	basicInfo := createBasicModelInfo()
+	s.assertAgentVersionPresent(c, basicInfo, jc.Contains)
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *ModelsSuite) TestListModelsWithNoAgent(c *gc.C) {
+	basicInfo := createBasicModelInfo()
+	basicInfo.AgentVersion = nil
+	s.assertAgentVersionPresent(c, basicInfo, gc.Not(jc.Contains))
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *ModelsSuite) newCommand() cmd.Command {
+	return controller.NewListModelsCommandForTest(s.api, s.api, s.store)
 }
 
 func (s *ModelsSuite) assertAgentVersionPresent(c *gc.C, testInfo *params.ModelInfo, checker gc.Checker) {
@@ -400,13 +440,62 @@ func (s *ModelsSuite) assertAgentVersionPresent(c *gc.C, testInfo *params.ModelI
 	c.Assert(cmdtesting.Stdout(context), checker, "agent-version")
 }
 
-func (s *ModelsSuite) TestListModelsWithAgent(c *gc.C) {
-	basicInfo := createBasicModelInfo()
-	s.assertAgentVersionPresent(c, basicInfo, jc.Contains)
+func (s *ModelsSuite) checkAPICalls(c *gc.C, expectedCalls ...string) {
+	actualCalls := []string{}
+
+	switch s.api.version {
+	case 4:
+		oldCalls := set.NewStrings("ModelInfo", "AllModels", "ListModels")
+		// need to add Close here too because in previous implementations it could
+		// have been called more than once.
+		oldCalls.Add("Close")
+		for _, call := range expectedCalls {
+			if !oldCalls.Contains(call) {
+				actualCalls = append(actualCalls, call)
+			}
+		}
+		actualCalls = append(actualCalls, "ListModelsWithInfo", "Close")
+	default:
+		actualCalls = expectedCalls
+	}
+
+	s.api.CheckCallNames(c, actualCalls...)
 }
 
-func (s *ModelsSuite) TestListModelsWithNoAgent(c *gc.C) {
-	basicInfo := createBasicModelInfo()
-	basicInfo.AgentVersion = nil
-	s.assertAgentVersionPresent(c, basicInfo, gc.Not(jc.Contains))
+func createBasicModelInfo() *params.ModelInfo {
+	agentVersion, _ := version.Parse("2.55.5")
+	return &params.ModelInfo{
+		Name:           "basic-model",
+		UUID:           testing.ModelTag.Id(),
+		ControllerUUID: testing.ControllerTag.Id(),
+		OwnerTag:       names.NewUserTag("owner").String(),
+		Life:           params.Dead,
+		CloudTag:       names.NewCloudTag("altostratus").String(),
+		CloudRegion:    "mid-level",
+		AgentVersion:   &agentVersion,
+	}
+}
+
+func convert(models []base.UserModel) []params.ModelInfoResult {
+	agentVersion, _ := version.Parse("2.55.5")
+	infoResults := make([]params.ModelInfoResult, len(models))
+	for i, model := range models {
+		infoResult := params.ModelInfoResult{}
+		infoResult.Result = &params.ModelInfo{
+			Name:         model.Name,
+			UUID:         model.UUID,
+			OwnerTag:     names.NewUserTag(model.Owner).String(),
+			CloudTag:     "cloud-dummy",
+			AgentVersion: &agentVersion,
+			Status:       params.EntityStatus{Status: status.Active},
+		}
+		infoResults[i] = infoResult
+	}
+	return infoResults
+}
+
+func (s *ModelsSuiteV4) SetUpTest(c *gc.C) {
+	s.ModelsSuite.SetUpTest(c)
+	// re-run all the test for ModelManager v4
+	s.ModelsSuite.api.version = 4
 }


### PR DESCRIPTION
## Description of change

Added backward compatibility for api facade. Added api v4 unit tests.
Assumed that 'oldAPI' flag on 'models' command is only there for manual testing and will not be committed to with the rest of the branch, so did not add tests for that.

Re-wrote test api mock to be more readable and maintainable.

Drive-by: if current model is not found in store, it is still an error -  no need to try to process it. 
