### PR TITLE
apiserver tests.

### DIFF
--- a/apiserver/facades/client/modelmanager/listmodelsinfo_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsinfo_test.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelmanager_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	_ "github.com/juju/juju/provider/azure"
+	_ "github.com/juju/juju/provider/ec2"
+	_ "github.com/juju/juju/provider/joyent"
+	_ "github.com/juju/juju/provider/maas"
+	_ "github.com/juju/juju/provider/openstack"
+)
+
+func (s *modelManagerStateSuite) TestListModelsWithInfoForSelf(c *gc.C) {
+	user := names.NewUserTag("external@remote")
+	s.setAPIUser(c, user)
+	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: user.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 0)
+}
+
+func (s *modelManagerStateSuite) TestListModelsWithInfoForSelfLocalUser(c *gc.C) {
+	// When the user's credentials cache stores the simple name, but the
+	// api server converts it to a fully qualified name.
+	user := names.NewUserTag("local-user")
+	s.setAPIUser(c, names.NewUserTag("local-user"))
+	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: user.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 0)
+}
+
+func (s *modelManagerStateSuite) TestListModelsWithInfoAdminSelf(c *gc.C) {
+	user := s.AdminUserTag(c)
+	s.setAPIUser(c, user)
+	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: user.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	expected, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	model := result.Results[0].Result
+	c.Check(model.Name, gc.Equals, expected.Name())
+	c.Check(model.UUID, gc.Equals, expected.UUID())
+	c.Check(model.OwnerTag, gc.Equals, expected.Owner().String())
+}
+
+func (s *modelManagerStateSuite) TestListModelsWithInfoAdminListsOther(c *gc.C) {
+	user := s.AdminUserTag(c)
+	s.setAPIUser(c, user)
+	other := names.NewUserTag("admin")
+	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: other.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+}
+
+func (s *modelManagerStateSuite) TestListModelsWithInfoDenied(c *gc.C) {
+	user := names.NewUserTag("external@remote")
+	s.setAPIUser(c, user)
+	other := names.NewUserTag("other@remote")
+	_, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: other.String()})
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}

--- a/apiserver/facades/client/modelmanager/listmodelsinfo_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsinfo_test.go
@@ -4,64 +4,174 @@
 package modelmanager_test
 
 import (
+	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/facades/client/modelmanager"
 	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/permission"
 	_ "github.com/juju/juju/provider/azure"
+	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/ec2"
 	_ "github.com/juju/juju/provider/joyent"
 	_ "github.com/juju/juju/provider/maas"
 	_ "github.com/juju/juju/provider/openstack"
+	"github.com/juju/juju/state"
+	jujuversion "github.com/juju/juju/version"
 )
 
-func (s *modelManagerStateSuite) TestListModelsWithInfoForSelf(c *gc.C) {
-	user := names.NewUserTag("external@remote")
-	s.setAPIUser(c, user)
-	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: user.String()})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 0)
+type ListModelsWithInfoSuite struct {
+	gitjujutesting.IsolationSuite
+
+	st *mockState
+
+	authoriser apiservertesting.FakeAuthorizer
+	adminUser  names.UserTag
+
+	api *modelmanager.ModelManagerAPI
 }
 
-func (s *modelManagerStateSuite) TestListModelsWithInfoForSelfLocalUser(c *gc.C) {
+var _ = gc.Suite(&ListModelsWithInfoSuite{})
+
+func (s *ListModelsWithInfoSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	adminUser := "admin"
+	s.adminUser = names.NewUserTag(adminUser)
+
+	s.st = &mockState{
+		model: s.createModel(c, s.adminUser),
+	}
+	s.st.modelDetailsForUser = func() ([]state.ModelDetails, error) {
+		return []state.ModelDetails{s.st.model.getModelDetails()}, s.st.NextErr()
+	}
+
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		Tag: s.adminUser,
+	}
+	api, err := modelmanager.NewModelManagerAPI(s.st, &mockState{}, nil, s.authoriser, s.st.model)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *ListModelsWithInfoSuite) createModel(c *gc.C, user names.UserTag) *mockModel {
+	attrs := dummy.SampleConfig()
+	attrs["agent-version"] = jujuversion.Current.String()
+	cfg, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return &mockModel{
+		owner: user,
+		cfg:   cfg,
+	}
+}
+
+func (s *ListModelsWithInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
+	s.authoriser.Tag = user
+	modelmanager, err := modelmanager.NewModelManagerAPI(s.st, &mockState{}, nil, s.authoriser, s.st.model)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = modelmanager
+}
+
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoForSelf(c *gc.C) {
+	user := names.NewUserTag("external@remote")
+	s.setAPIUser(c, user)
+	s.st.model = s.createModel(c, user)
+	result, err := s.api.ListModelsWithInfo(params.Entity{Tag: user.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+}
+
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoForSelfLocalUser(c *gc.C) {
 	// When the user's credentials cache stores the simple name, but the
 	// api server converts it to a fully qualified name.
 	user := names.NewUserTag("local-user")
-	s.setAPIUser(c, names.NewUserTag("local-user"))
-	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: user.String()})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 0)
-}
-
-func (s *modelManagerStateSuite) TestListModelsWithInfoAdminSelf(c *gc.C) {
-	user := s.AdminUserTag(c)
 	s.setAPIUser(c, user)
-	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: user.String()})
+	s.st.model = s.createModel(c, user)
+	result, err := s.api.ListModelsWithInfo(params.Entity{Tag: user.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	expected, err := s.State.Model()
+}
+
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoAdminSelf(c *gc.C) {
+	result, err := s.api.ListModelsWithInfo(params.Entity{Tag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
 
 	model := result.Results[0].Result
-	c.Check(model.Name, gc.Equals, expected.Name())
-	c.Check(model.UUID, gc.Equals, expected.UUID())
-	c.Check(model.OwnerTag, gc.Equals, expected.Owner().String())
+	c.Check(model.Name, gc.Equals, "only")
+	c.Check(model.OwnerTag, gc.Equals, s.adminUser.String())
 }
 
-func (s *modelManagerStateSuite) TestListModelsWithInfoAdminListsOther(c *gc.C) {
-	user := s.AdminUserTag(c)
-	s.setAPIUser(c, user)
-	other := names.NewUserTag("admin")
-	result, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: other.String()})
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoAdminListsOther(c *gc.C) {
+	otherTag := names.NewUserTag("someotheruser")
+	s.st.model = s.createModel(c, otherTag)
+	result, err := s.api.ListModelsWithInfo(params.Entity{Tag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Result.OwnerTag, gc.DeepEquals, otherTag.String())
 }
 
-func (s *modelManagerStateSuite) TestListModelsWithInfoDenied(c *gc.C) {
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoDenied(c *gc.C) {
 	user := names.NewUserTag("external@remote")
 	s.setAPIUser(c, user)
 	other := names.NewUserTag("other@remote")
-	_, err := s.modelmanager.ListModelsWithInfo(params.Entity{Tag: other.String()})
+	_, err := s.api.ListModelsWithInfo(params.Entity{Tag: other.String()})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoInvalidUser(c *gc.C) {
+	_, err := s.api.ListModelsWithInfo(params.Entity{Tag: "invalid"})
+	c.Assert(err, gc.ErrorMatches, `"invalid" is not a valid tag`)
+}
+
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoStateError(c *gc.C) {
+	errMsg := "captain error for ModelDetailsForUser"
+	s.st.Stub.SetErrors(errors.New(errMsg))
+	_, err := s.api.ListModelsWithInfo(params.Entity{Tag: s.adminUser.String()})
+	c.Assert(err, gc.ErrorMatches, errMsg)
+}
+
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoNoModelsForUser(c *gc.C) {
+	s.st.modelDetailsForUser = func() ([]state.ModelDetails, error) {
+		return []state.ModelDetails{}, nil
+	}
+	results, err := s.api.ListModelsWithInfo(params.Entity{Tag: s.adminUser.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 0)
+}
+
+func (s *ListModelsWithInfoSuite) TestListModelsWithInfoForJustAModelUser(c *gc.C) {
+	other := "other"
+	otherTag := names.NewUserTag(other)
+	s.setAPIUser(c, otherTag)
+	s.st.modelDetailsForUser = func() ([]state.ModelDetails, error) {
+		details := s.st.model.getModelDetails()
+		details.Users = map[string]state.UserAccessInfo{
+			"admin": state.UserAccessInfo{},
+			"other": state.UserAccessInfo{
+				UserAccess: permission.UserAccess{
+					UserTag:  names.NewUserTag(other),
+					Access:   permission.ReadAccess,
+					UserName: other,
+				},
+			},
+		}
+		return []state.ModelDetails{details}, s.st.NextErr()
+	}
+
+	results, err := s.api.ListModelsWithInfo(params.Entity{Tag: otherTag.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Result.Users, jc.DeepEquals, []params.ModelUserInfo{
+		params.ModelUserInfo{
+			UserName: other,
+			Access:   "read",
+		},
+	})
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -558,6 +558,8 @@ type mockState struct {
 	block           state.BlockType
 	migration       *mockMigration
 	modelConfig     *config.Config
+
+	modelDetailsForUser func() ([]state.ModelDetails, error)
 }
 
 type fakeModelDescription struct {
@@ -744,7 +746,7 @@ func (st *mockState) ModelSummariesForUser(user names.UserTag) ([]state.ModelAcc
 
 func (st *mockState) ModelDetailsForUser(user names.UserTag) ([]state.ModelDetails, error) {
 	st.MethodCall(st, "ModelDetailsForUser", user)
-	return []state.ModelDetails{}, st.NextErr()
+	return st.modelDetailsForUser()
 }
 
 func (st *mockState) RemoveUserAccess(subject names.UserTag, target names.Tag) error {
@@ -1027,6 +1029,22 @@ func (m *mockModel) AutoConfigureContainerNetworking(environ environs.Environ) e
 func (m *mockModel) ModelConfigDefaultValues() (config.ModelDefaultAttributes, error) {
 	m.MethodCall(m, "ModelConfigDefaultValues")
 	return m.cfgDefaults, nil
+}
+
+func (m *mockModel) getModelDetails() state.ModelDetails {
+	cred, _ := m.CloudCredential()
+	return state.ModelDetails{
+		Name:               m.Name(),
+		UUID:               m.UUID(),
+		Life:               m.Life(),
+		Owner:              m.Owner().Id(),
+		ControllerUUID:     m.ControllerUUID(),
+		SLALevel:           m.SLALevel(),
+		SLAOwner:           m.SLAOwner(),
+		CloudTag:           m.Cloud(),
+		CloudRegion:        m.CloudRegion(),
+		CloudCredentialTag: cred.String(),
+	}
 }
 
 type mockModelUser struct {

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -737,6 +737,15 @@ func (st *mockState) UserAccess(tag names.UserTag, target names.Tag) (permission
 	}
 	return permission.UserAccess{}, st.NextErr()
 }
+func (st *mockState) ModelSummariesForUser(user names.UserTag) ([]state.ModelAccessInfo, error) {
+	st.MethodCall(st, "ModelSummariesForUser", user)
+	return []state.ModelAccessInfo{}, st.NextErr()
+}
+
+func (st *mockState) ModelDetailsForUser(user names.UserTag) ([]state.ModelDetails, error) {
+	st.MethodCall(st, "ModelDetailsForUser", user)
+	return []state.ModelDetails{}, st.NextErr()
+}
 
 func (st *mockState) RemoveUserAccess(subject names.UserTag, target names.Tag) error {
 	st.MethodCall(st, "RemoveUserAccess", subject, target)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -730,9 +730,8 @@ func (m *ModelManagerAPI) ListModelsWithInfo(user params.Entity) (params.ModelIn
 		authorizedOwner := m.authCheck(names.NewUserTag(mi.Owner)) == nil
 		for _, user := range mi.Users {
 			if !authorizedOwner && m.authCheck(user.UserTag) != nil {
-				// The authenticated user is neither the owner
-				// nor administrator, nor the model user, so
-				// has no business knowing about the model user.
+				// The authenticated user is not an admin,
+				// so should only see themselves in the list of model users.
 				continue
 			}
 

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -47,6 +47,7 @@ type ModelManagerV4 interface {
 	ListModels(user params.Entity) (params.UserModelList, error)
 	DestroyModels(args params.DestroyModelsParams) (params.ErrorResults, error)
 	ModelInfo(args params.Entities) (params.ModelInfoResults, error)
+	ModelStatus(req params.Entities) (params.ModelStatusResults, error)
 }
 
 // ModelManagerV3 defines the methods on the version 2 facade for the
@@ -58,6 +59,7 @@ type ModelManagerV3 interface {
 	ListModels(user params.Entity) (params.UserModelList, error)
 	DestroyModels(args params.Entities) (params.ErrorResults, error)
 	ModelInfo(args params.Entities) (params.ModelInfoResults, error)
+	ModelStatus(req params.Entities) (params.ModelStatusResults, error)
 }
 
 // ModelManagerV2 defines the methods on the version 2 facade for the
@@ -68,6 +70,7 @@ type ModelManagerV2 interface {
 	DumpModelsDB(args params.Entities) params.MapResults
 	ListModels(user params.Entity) (params.UserModelList, error)
 	DestroyModels(args params.Entities) (params.ErrorResults, error)
+	ModelStatus(req params.Entities) (params.ModelStatusResults, error)
 }
 
 // ModelManagerAPI implements the model manager interface and is


### PR DESCRIPTION
## Description of change

Added equivalent coverage to listmodelswithinfo based on current list models coverage - beginning of full on unit tests.

Added ModelStatus to facades interfaces.
Added new state methods to test mock.


