### PR TITLE
Updated cmd for models; renamed api calls to ListModelSummaries, etc.

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -179,9 +179,9 @@ func (c *Client) ListModels(user string) ([]base.UserModel, error) {
 	return result, nil
 }
 
-func (c *Client) ListModelsWithInfo(user names.UserTag) ([]params.ModelSummaryResult, error) {
+func (c *Client) ListModelSummaries(user names.UserTag) ([]params.ModelSummaryResult, error) {
 	var results params.ModelSummaryResults
-	err := c.facade.FacadeCall("ListModelsWithInfo", params.Entity{user.String()}, &results)
+	err := c.facade.FacadeCall("ListModelSummaries", params.Entity{user.String()}, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -404,7 +404,7 @@ func (s *modelmanagerSuite) TestModelStatusError(c *gc.C) {
 	c.Assert(out, gc.IsNil)
 }
 
-func (s *modelmanagerSuite) TestListModelsWithInfo(c *gc.C) {
+func (s *modelmanagerSuite) TesListModelSummaries(c *gc.C) {
 	userTag := names.NewUserTag("commander")
 	modelInfo := params.ModelSummary{
 		Name:               "name",
@@ -418,7 +418,7 @@ func (s *modelmanagerSuite) TestListModelsWithInfo(c *gc.C) {
 		OwnerTag:           "user-admin",
 		Life:               params.Alive,
 		Status:             params.EntityStatus{Status: status.Status("active")},
-		User:               params.ModelUserInfo{},
+		UserAccess:         params.ModelAdminAccess,
 		Counts:             []params.ModelEntityCount{},
 	}
 
@@ -427,7 +427,7 @@ func (s *modelmanagerSuite) TestListModelsWithInfo(c *gc.C) {
 		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
 			c.Check(objType, gc.Equals, "ModelManager")
 			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListModelsWithInfo")
+			c.Check(request, gc.Equals, "ListModelSummaries")
 			c.Check(arg, gc.Equals, params.Entity{Tag: userTag.String()})
 			c.Check(result, gc.FitsTypeOf, &params.ModelSummaryResults{})
 
@@ -441,7 +441,7 @@ func (s *modelmanagerSuite) TestListModelsWithInfo(c *gc.C) {
 	}
 
 	client := modelmanager.NewClient(apiCaller)
-	results, err := client.ListModelsWithInfo(userTag)
+	results, err := client.ListModelSummaries(userTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []params.ModelSummaryResult{
 		{Result: &modelInfo},
@@ -449,14 +449,14 @@ func (s *modelmanagerSuite) TestListModelsWithInfo(c *gc.C) {
 	})
 }
 
-func (s *modelmanagerSuite) TestListModelsWithInfoError(c *gc.C) {
+func (s *modelmanagerSuite) TestListModelSummariesError(c *gc.C) {
 	userTag := names.NewUserTag("captain")
 	apiCaller := basetesting.APICallerFunc(
 		func(objType string, version int, id, request string, args, result interface{}) error {
 			return errors.New("captain, error")
 		})
 	client := modelmanager.NewClient(apiCaller)
-	out, err := client.ListModelsWithInfo(userTag)
+	out, err := client.ListModelSummaries(userTag)
 	c.Assert(err, gc.ErrorMatches, "captain, error")
 	c.Assert(out, gc.IsNil)
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -739,14 +739,15 @@ func (st *mockState) UserAccess(tag names.UserTag, target names.Tag) (permission
 	}
 	return permission.UserAccess{}, st.NextErr()
 }
-func (st *mockState) ModelSummariesForUser(user names.UserTag) ([]state.ModelAccessInfo, error) {
-	st.MethodCall(st, "ModelBasicInfoForUser", user)
-	return []state.ModelAccessInfo{}, st.NextErr()
-}
 
-func (st *mockState) ModelDetailsForUser(user names.UserTag) ([]state.ModelSummary, error) {
+func (st *mockState) ModelSummariesForUser(user names.UserTag) ([]state.ModelSummary, error) {
 	st.MethodCall(st, "ModelSummariesForUser", user)
 	return st.modelDetailsForUser()
+}
+
+func (st *mockState) ModelBasicInfoForUser(user names.UserTag) ([]state.ModelAccessInfo, error) {
+	st.MethodCall(st, "ModelBasicInfoForUser", user)
+	return []state.ModelAccessInfo{}, st.NextErr()
 }
 
 func (st *mockState) RemoveUserAccess(subject names.UserTag, target names.Tag) error {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -183,9 +183,12 @@ type ModelSummary struct {
 	// Status is the current status of the model.
 	Status EntityStatus `json:"status,omitempty"`
 
-	// User contains information about current user's access
-	// to the model.
-	User ModelUserInfo `json:"user"`
+	// UserAccess is model access level for the  current user.
+	UserAccess UserAccessPermission `json:"user-access"`
+
+	// UserLastConnection contains the time when current user logged in
+	// into the model last.
+	UserLastConnection *time.Time `json:"last-connection"`
 
 	// Counts contains counts of interesting entities
 	// in the model, for example machines, cores, containers, units, etc.
@@ -206,7 +209,7 @@ type ModelSummary struct {
 // machines, units, etc...
 type ModelEntityCount struct {
 	Entity CountedEntity `json:"entity"`
-	Count  uint64        `json:"count"`
+	Count  int64         `json:"count"`
 }
 
 // CountedEntity identifies an entity that has a count.

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -63,9 +63,9 @@ type ModelUserInfo struct {
 	LastConnection string `yaml:"last-connection" json:"last-connection"`
 }
 
-// friendlyDuration renders a time pointer that we get from the API as
+// FriendlyDuration renders a time pointer that we get from the API as
 // a friendly string.
-func friendlyDuration(when *time.Time, now time.Time) string {
+func FriendlyDuration(when *time.Time, now time.Time) string {
 	if when == nil {
 		return ""
 	}
@@ -102,7 +102,7 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		modelInfo.Status = &ModelStatus{
 			Current: info.Status.Status,
 			Message: info.Status.Info,
-			Since:   friendlyDuration(info.Status.Since, now),
+			Since:   FriendlyDuration(info.Status.Since, now),
 		}
 	}
 	if info.Migration != nil {
@@ -112,8 +112,8 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 			modelInfo.Status = status
 		}
 		status.Migration = info.Migration.Status
-		status.MigrationStart = friendlyDuration(info.Migration.Start, now)
-		status.MigrationEnd = friendlyDuration(info.Migration.End, now)
+		status.MigrationStart = FriendlyDuration(info.Migration.Start, now)
+		status.MigrationEnd = FriendlyDuration(info.Migration.End, now)
 	}
 
 	if info.ProviderType != "" {
@@ -127,8 +127,8 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		modelInfo.Machines = ModelMachineInfoFromParams(info.Machines)
 	}
 	if info.SLA != nil {
-		modelInfo.SLA = modelSLAFromParams(info.SLA)
-		modelInfo.SLAOwner = modelSLAOwnerFromParams(info.SLA)
+		modelInfo.SLA = ModelSLAFromParams(info.SLA)
+		modelInfo.SLAOwner = ModelSLAOwnerFromParams(info.SLA)
 	}
 	return modelInfo, nil
 }
@@ -166,14 +166,14 @@ func ModelUserInfoFromParams(users []params.ModelUserInfo, now time.Time) map[st
 	return output
 }
 
-func modelSLAFromParams(sla *params.ModelSLAInfo) string {
+func ModelSLAFromParams(sla *params.ModelSLAInfo) string {
 	if sla == nil {
 		return ""
 	}
 	return sla.Level
 }
 
-func modelSLAOwnerFromParams(sla *params.ModelSLAInfo) string {
+func ModelSLAOwnerFromParams(sla *params.ModelSLAInfo) string {
 	if sla == nil {
 		return ""
 	}

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -25,17 +25,21 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type ModelsSuite struct {
+type BaseModelsSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	api   *fakeModelMgrAPIClient
 	store *jujuclient.MemStore
 }
 
-type ModelsSuiteV4 struct {
-	ModelsSuite
+type ModelsSuiteV3 struct {
+	BaseModelsSuite
 }
 
-var _ = gc.Suite(&ModelsSuite{})
+type ModelsSuiteV4 struct {
+	BaseModelsSuite
+}
+
+var _ = gc.Suite(&ModelsSuiteV3{})
 var _ = gc.Suite(&ModelsSuiteV4{})
 
 type fakeModelMgrAPIClient struct {
@@ -73,8 +77,8 @@ func (f *fakeModelMgrAPIClient) AllModels() ([]base.UserModel, error) {
 	return f.convertInfosToUserModels(), nil
 }
 
-func (f *fakeModelMgrAPIClient) ListModelsWithInfo(user names.UserTag) ([]params.ModelSummaryResult, error) {
-	f.MethodCall(f, "ListModelsWithInfo", user)
+func (f *fakeModelMgrAPIClient) ListModelSummaries(user names.UserTag) ([]params.ModelSummaryResult, error) {
+	f.MethodCall(f, "ListModelSummaries", user)
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -102,12 +106,21 @@ func (f *fakeModelMgrAPIClient) ListModelsWithInfo(user names.UserTag) ([]params
 			AgentVersion:       info.Result.AgentVersion,
 		}
 		if len(info.Result.Users) > 0 {
-			results[i].Result.User = info.Result.Users[0]
+			results[i].Result.UserAccess = info.Result.Users[0].Access
+			results[i].Result.UserLastConnection = info.Result.Users[0].LastConnection
 		}
-		// TODO (anastasiamac 2017-11-22) need to cater for cores count too
 		if len(info.Result.Machines) > 0 {
 			results[i].Result.Counts = []params.ModelEntityCount{
-				params.ModelEntityCount{params.Machines, len(info.Result.Machines)},
+				params.ModelEntityCount{params.Machines, int64(len(info.Result.Machines))},
+			}
+			cores := uint64(0)
+			for _, machine := range info.Result.Machines {
+				if machine.Hardware != nil && machine.Hardware.Cores != nil {
+					cores += *machine.Hardware.Cores
+				}
+			}
+			if cores > 0 {
+				results[i].Result.Counts = append(results[i].Result.Counts, params.ModelEntityCount{params.Cores, int64(cores)})
 			}
 		}
 	}
@@ -143,7 +156,7 @@ func (f *fakeModelMgrAPIClient) convertInfosToUserModels() []base.UserModel {
 	return models
 }
 
-func (s *ModelsSuite) SetUpTest(c *gc.C) {
+func (s *BaseModelsSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
 	models := []base.UserModel{
@@ -200,7 +213,7 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 	s.api.infos[2].Result.Status.Status = status.Destroying
 }
 
-func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
+func (s *BaseModelsSuite) TestModelsOwner(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
@@ -214,7 +227,282 @@ func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
-func (s *ModelsSuite) TestModelsYaml(c *gc.C) {
+func (s *BaseModelsSuite) TestModelsNonOwner(c *gc.C) {
+	// Ensure fake api caters to user 'bob'
+	for _, apiInfo := range s.api.infos {
+		if apiInfo.Error == nil {
+			bobs := make([]params.ModelUserInfo, len(apiInfo.Result.Users))
+			for i, u := range apiInfo.Result.Users {
+				u.UserName = "bob"
+				bobs[i] = u
+			}
+			apiInfo.Result.Users = bobs
+		}
+	}
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "bob")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
+		"Controller: fake\n"+
+		"\n"+
+		"Model                        Cloud/Region  Status      Access  Last connection\n"+
+		"admin/test-model1*           dummy         active      read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
+		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) TestAllModels(c *gc.C) {
+	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--all")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
+		"Controller: fake\n"+
+		"\n"+
+		"Model                        Cloud/Region  Status      Access  Last connection\n"+
+		"test-model1*                 dummy         active      read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
+		"\n")
+	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
+		"admin/test-model1":           jujuclient.ModelDetails{"test-model1-UUID"},
+		"carlotta/test-model2":        jujuclient.ModelDetails{"test-model2-UUID"},
+		"daiwik@external/test-model3": jujuclient.ModelDetails{"test-model3-UUID"},
+	})
+	s.checkAPICalls(c, "BestAPIVersion", "AllModels", "Close", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
+	delete(s.store.Models, "fake")
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
+		"Controller: fake\n"+
+		"\n"+
+		"Model                        Cloud/Region  Status      Access  Last connection\n"+
+		"test-model1                  dummy         active      read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
+		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) TestModelsUUID(c *gc.C) {
+	one := uint64(1)
+	s.api.infos[0].Result.Machines = []params.ModelMachineInfo{
+		{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
+	}
+
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--uuid")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
+		"Controller: fake\n"+
+		"\n"+
+		"Model                        UUID              Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
+		"test-model1*                 test-model1-UUID  dummy         active             2      1  read    2015-03-20\n"+
+		"carlotta/test-model2         test-model2-UUID  dummy         active             0      -  write   2015-03-01\n"+
+		"daiwik@external/test-model3  test-model3-UUID  dummy         destroying         0      -  -       never connected\n"+
+		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) TestModelsMachineInfo(c *gc.C) {
+	one := uint64(1)
+	s.api.infos[0].Result.Machines = []params.ModelMachineInfo{
+		{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
+	}
+
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
+		"Controller: fake\n"+
+		"\n"+
+		"Model                        Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
+		"test-model1*                 dummy         active             2      1  read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         active             0      -  write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         destroying         0      -  -       never connected\n"+
+		"\n")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+// This test is only needed for older api versions as
+// whether the user has an access to a model will be checked on
+// the api side and the model data will not be sent.
+func (s *BaseModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
+	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
+	s.api.infos[2].Error = &params.Error{
+		Message: "permission denied",
+		Code:    params.CodeUnauthorized,
+	}
+
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
+		"Controller: fake\n"+
+		"\n"+
+		"Model                 Cloud/Region  Status  Access  Last connection\n"+
+		"test-model1*          dummy         active  read    2015-03-20\n"+
+		"carlotta/test-model2  dummy         active  write   2015-03-01\n"+
+		"\n")
+	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
+		"admin/test-model1":    jujuclient.ModelDetails{"test-model1-UUID"},
+		"carlotta/test-model2": jujuclient.ModelDetails{"test-model2-UUID"},
+	})
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) TestUnrecognizedArg(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newCommand(), "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+	s.api.CheckNoCalls(c)
+}
+
+func (s *BaseModelsSuite) TestInvalidUser(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "+bob")
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`user "+bob" not valid`))
+	s.api.CheckNoCalls(c)
+}
+
+func (s *BaseModelsSuite) TestModelsError(c *gc.C) {
+	s.api.err = common.ErrPerm
+	_, err := cmdtesting.RunCommand(c, s.newCommand())
+	c.Assert(err, gc.ErrorMatches, ".*: permission denied")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "Close")
+}
+
+func (s *BaseModelsSuite) TestWithIncompleteModels(c *gc.C) {
+	basicAndStatusInfo := createBasicModelInfo()
+	basicAndStatusInfo.Status = params.EntityStatus{
+		Status: status.Busy,
+	}
+
+	basicAndUsersInfo := createBasicModelInfo()
+	basicAndUsersInfo.Users = []params.ModelUserInfo{
+		params.ModelUserInfo{"admin", "display name", nil, params.UserAccessPermission("admin")},
+	}
+
+	basicAndMachinesInfo := createBasicModelInfo()
+	basicAndMachinesInfo.Machines = []params.ModelMachineInfo{
+		params.ModelMachineInfo{Id: "2"},
+		params.ModelMachineInfo{Id: "12"},
+	}
+
+	s.api.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: createBasicModelInfo()},
+		params.ModelInfoResult{Result: basicAndStatusInfo},
+		params.ModelInfoResult{Result: basicAndUsersInfo},
+		params.ModelInfoResult{Result: basicAndMachinesInfo},
+	}
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+Controller: fake
+
+Model              Cloud/Region           Status  Machines  Access  Last connection
+owner/basic-model  altostratus/mid-level  -              0  -       never connected
+owner/basic-model  altostratus/mid-level  busy           0  -       never connected
+owner/basic-model  altostratus/mid-level  -              0  admin   never connected
+owner/basic-model  altostratus/mid-level  -              2  -       never connected
+
+`[1:])
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) TestListModelsWithAgent(c *gc.C) {
+	basicInfo := createBasicModelInfo()
+	s.assertAgentVersionPresent(c, basicInfo, jc.Contains)
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) TestListModelsWithNoAgent(c *gc.C) {
+	basicInfo := createBasicModelInfo()
+	basicInfo.AgentVersion = nil
+	s.assertAgentVersionPresent(c, basicInfo, gc.Not(jc.Contains))
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *BaseModelsSuite) newCommand() cmd.Command {
+	return controller.NewListModelsCommandForTest(s.api, s.api, s.store)
+}
+
+func (s *BaseModelsSuite) assertAgentVersionPresent(c *gc.C, testInfo *params.ModelInfo, checker gc.Checker) {
+	s.api.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: testInfo},
+	}
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format=yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), checker, "agent-version")
+}
+
+func (s *BaseModelsSuite) checkAPICalls(c *gc.C, expectedCalls ...string) {
+	actualCalls := []string{}
+
+	switch s.api.version {
+	case 4:
+		oldCalls := set.NewStrings("ModelInfo", "AllModels", "ListModels")
+		// need to add Close here too because in previous implementations it could
+		// have been called more than once.
+		oldCalls.Add("Close")
+		for _, call := range expectedCalls {
+			if !oldCalls.Contains(call) {
+				actualCalls = append(actualCalls, call)
+			}
+		}
+		actualCalls = append(actualCalls, "ListModelSummaries", "Close")
+	default:
+		actualCalls = expectedCalls
+	}
+
+	s.api.CheckCallNames(c, actualCalls...)
+}
+
+func createBasicModelInfo() *params.ModelInfo {
+	agentVersion, _ := version.Parse("2.55.5")
+	return &params.ModelInfo{
+		Name:           "basic-model",
+		UUID:           testing.ModelTag.Id(),
+		ControllerUUID: testing.ControllerTag.Id(),
+		OwnerTag:       names.NewUserTag("owner").String(),
+		Life:           params.Dead,
+		CloudTag:       names.NewCloudTag("altostratus").String(),
+		CloudRegion:    "mid-level",
+		AgentVersion:   &agentVersion,
+	}
+}
+
+func convert(models []base.UserModel) []params.ModelInfoResult {
+	agentVersion, _ := version.Parse("2.55.5")
+	infoResults := make([]params.ModelInfoResult, len(models))
+	for i, model := range models {
+		infoResult := params.ModelInfoResult{}
+		infoResult.Result = &params.ModelInfo{
+			Name:         model.Name,
+			UUID:         model.UUID,
+			OwnerTag:     names.NewUserTag(model.Owner).String(),
+			CloudTag:     "cloud-dummy",
+			AgentVersion: &agentVersion,
+			Status:       params.EntityStatus{Status: status.Active},
+		}
+		infoResults[i] = infoResult
+	}
+	return infoResults
+}
+
+func (s *ModelsSuiteV3) SetUpTest(c *gc.C) {
+	s.BaseModelsSuite.SetUpTest(c)
+	// re-run all the test for ModelManager v3
+	s.BaseModelsSuite.api.version = 3
+}
+
+func (s *ModelsSuiteV3) TestModelsJson(c *gc.C) {
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"test-model1"}
+`)
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
+func (s *ModelsSuiteV3) TestModelsYaml(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
@@ -265,277 +553,65 @@ current-model: test-model1
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
-func (s *ModelsSuite) TestModelsJson(c *gc.C) {
+func (s *ModelsSuiteV4) SetUpTest(c *gc.C) {
+	s.BaseModelsSuite.SetUpTest(c)
+	// re-run all the test for ModelManager v4
+	s.BaseModelsSuite.api.version = 4
+}
+
+func (s *ModelsSuiteV4) TestModelsJson(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"test-model1"}
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"access":"read","last-connection":"2015-03-20","agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"access":"write","last-connection":"2015-03-01","agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"access":"","last-connection":"never connected","agent-version":"2.55.5"}],"current-model":"test-model1"}
 `)
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
-func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
-	// Ensure fake api caters to user 'bob'
-	for _, apiInfo := range s.api.infos {
-		if apiInfo.Error == nil {
-			bobs := make([]params.ModelUserInfo, len(apiInfo.Result.Users))
-			for i, u := range apiInfo.Result.Users {
-				u.UserName = "bob"
-				bobs[i] = u
-			}
-			apiInfo.Result.Users = bobs
-		}
-	}
-	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "bob")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: fake\n"+
-		"\n"+
-		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"admin/test-model1*           dummy         active      read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
-		"\n")
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) TestAllModels(c *gc.C) {
-	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
-	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--all")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: fake\n"+
-		"\n"+
-		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"test-model1*                 dummy         active      read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
-		"\n")
-	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
-		"admin/test-model1":           jujuclient.ModelDetails{"test-model1-UUID"},
-		"carlotta/test-model2":        jujuclient.ModelDetails{"test-model2-UUID"},
-		"daiwik@external/test-model3": jujuclient.ModelDetails{"test-model3-UUID"},
-	})
-	s.checkAPICalls(c, "BestAPIVersion", "AllModels", "Close", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
-	delete(s.store.Models, "fake")
-	context, err := cmdtesting.RunCommand(c, s.newCommand())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: fake\n"+
-		"\n"+
-		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"test-model1                  dummy         active      read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
-		"\n")
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
-	one := uint64(1)
-	s.api.infos[0].Result.Machines = []params.ModelMachineInfo{
-		{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
-	}
-
-	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--uuid")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: fake\n"+
-		"\n"+
-		"Model                        UUID              Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
-		"test-model1*                 test-model1-UUID  dummy         active             2      1  read    2015-03-20\n"+
-		"carlotta/test-model2         test-model2-UUID  dummy         active             0      -  write   2015-03-01\n"+
-		"daiwik@external/test-model3  test-model3-UUID  dummy         destroying         0      -  -       never connected\n"+
-		"\n")
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
-	one := uint64(1)
-	s.api.infos[0].Result.Machines = []params.ModelMachineInfo{
-		{Id: "0", Hardware: &params.MachineHardware{Cores: &one}}, {Id: "1"},
-	}
-
-	context, err := cmdtesting.RunCommand(c, s.newCommand())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: fake\n"+
-		"\n"+
-		"Model                        Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
-		"test-model1*                 dummy         active             2      1  read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active             0      -  write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying         0      -  -       never connected\n"+
-		"\n")
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-// This test is only needed for older api versions as
-// whether the user has an access to a model will be checked on
-// the api side and the model data will not be sent.
-func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
-	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
-	s.api.infos[2].Error = &params.Error{
-		Message: "permission denied",
-		Code:    params.CodeUnauthorized,
-	}
-
-	context, err := cmdtesting.RunCommand(c, s.newCommand())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: fake\n"+
-		"\n"+
-		"Model                 Cloud/Region  Status  Access  Last connection\n"+
-		"test-model1*          dummy         active  read    2015-03-20\n"+
-		"carlotta/test-model2  dummy         active  write   2015-03-01\n"+
-		"\n")
-	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
-		"admin/test-model1":    jujuclient.ModelDetails{"test-model1-UUID"},
-		"carlotta/test-model2": jujuclient.ModelDetails{"test-model2-UUID"},
-	})
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) TestUnrecognizedArg(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, s.newCommand(), "whoops")
-	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
-	s.api.CheckNoCalls(c)
-}
-
-func (s *ModelsSuite) TestInvalidUser(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "+bob")
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`user "+bob" not valid`))
-	s.api.CheckNoCalls(c)
-}
-
-func (s *ModelsSuite) TestModelsError(c *gc.C) {
-	s.api.err = common.ErrPerm
-	_, err := cmdtesting.RunCommand(c, s.newCommand())
-	c.Assert(err, gc.ErrorMatches, ".*: permission denied")
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "Close")
-}
-
-func (s *ModelsSuite) TestWithIncompleteModels(c *gc.C) {
-	basicAndStatusInfo := createBasicModelInfo()
-	basicAndStatusInfo.Status = params.EntityStatus{
-		Status: status.Busy,
-	}
-
-	basicAndUsersInfo := createBasicModelInfo()
-	basicAndUsersInfo.Users = []params.ModelUserInfo{
-		params.ModelUserInfo{"admin", "display name", nil, params.UserAccessPermission("admin")},
-	}
-
-	basicAndMachinesInfo := createBasicModelInfo()
-	basicAndMachinesInfo.Machines = []params.ModelMachineInfo{
-		params.ModelMachineInfo{Id: "2"},
-		params.ModelMachineInfo{Id: "12"},
-	}
-
-	s.api.infos = []params.ModelInfoResult{
-		params.ModelInfoResult{Result: createBasicModelInfo()},
-		params.ModelInfoResult{Result: basicAndStatusInfo},
-		params.ModelInfoResult{Result: basicAndUsersInfo},
-		params.ModelInfoResult{Result: basicAndMachinesInfo},
-	}
-	context, err := cmdtesting.RunCommand(c, s.newCommand())
+func (s *ModelsSuiteV4) TestModelsYaml(c *gc.C) {
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
-Controller: fake
-
-Model              Cloud/Region           Status  Machines  Cores  Access  Last connection
-owner/basic-model  altostratus/mid-level  -              0      -  -       never connected
-owner/basic-model  altostratus/mid-level  busy           0      -  -       never connected
-owner/basic-model  altostratus/mid-level  -              0      -  admin   never connected
-owner/basic-model  altostratus/mid-level  -              2      -  -       never connected
-
+models:
+- name: admin/test-model1
+  short-name: test-model1
+  model-uuid: test-model1-UUID
+  controller-uuid: ""
+  controller-name: fake
+  owner: admin
+  cloud: dummy
+  life: ""
+  status:
+    current: active
+  access: read
+  last-connection: 2015-03-20
+  agent-version: 2.55.5
+- name: carlotta/test-model2
+  short-name: test-model2
+  model-uuid: test-model2-UUID
+  controller-uuid: ""
+  controller-name: fake
+  owner: carlotta
+  cloud: dummy
+  life: ""
+  status:
+    current: active
+  access: write
+  last-connection: 2015-03-01
+  agent-version: 2.55.5
+- name: daiwik@external/test-model3
+  short-name: test-model3
+  model-uuid: test-model3-UUID
+  controller-uuid: ""
+  controller-name: fake
+  owner: daiwik@external
+  cloud: dummy
+  life: ""
+  status:
+    current: destroying
+  access: ""
+  last-connection: never connected
+  agent-version: 2.55.5
+current-model: test-model1
 `[1:])
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) TestListModelsWithAgent(c *gc.C) {
-	basicInfo := createBasicModelInfo()
-	s.assertAgentVersionPresent(c, basicInfo, jc.Contains)
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) TestListModelsWithNoAgent(c *gc.C) {
-	basicInfo := createBasicModelInfo()
-	basicInfo.AgentVersion = nil
-	s.assertAgentVersionPresent(c, basicInfo, gc.Not(jc.Contains))
-	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
-}
-
-func (s *ModelsSuite) newCommand() cmd.Command {
-	return controller.NewListModelsCommandForTest(s.api, s.api, s.store)
-}
-
-func (s *ModelsSuite) assertAgentVersionPresent(c *gc.C, testInfo *params.ModelInfo, checker gc.Checker) {
-	s.api.infos = []params.ModelInfoResult{
-		params.ModelInfoResult{Result: testInfo},
-	}
-	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format=yaml")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), checker, "agent-version")
-}
-
-func (s *ModelsSuite) checkAPICalls(c *gc.C, expectedCalls ...string) {
-	actualCalls := []string{}
-
-	switch s.api.version {
-	case 4:
-		oldCalls := set.NewStrings("ModelInfo", "AllModels", "ListModels")
-		// need to add Close here too because in previous implementations it could
-		// have been called more than once.
-		oldCalls.Add("Close")
-		for _, call := range expectedCalls {
-			if !oldCalls.Contains(call) {
-				actualCalls = append(actualCalls, call)
-			}
-		}
-		actualCalls = append(actualCalls, "ListModelsWithInfo", "Close")
-	default:
-		actualCalls = expectedCalls
-	}
-
-	s.api.CheckCallNames(c, actualCalls...)
-}
-
-func createBasicModelInfo() *params.ModelInfo {
-	agentVersion, _ := version.Parse("2.55.5")
-	return &params.ModelInfo{
-		Name:           "basic-model",
-		UUID:           testing.ModelTag.Id(),
-		ControllerUUID: testing.ControllerTag.Id(),
-		OwnerTag:       names.NewUserTag("owner").String(),
-		Life:           params.Dead,
-		CloudTag:       names.NewCloudTag("altostratus").String(),
-		CloudRegion:    "mid-level",
-		AgentVersion:   &agentVersion,
-	}
-}
-
-func convert(models []base.UserModel) []params.ModelInfoResult {
-	agentVersion, _ := version.Parse("2.55.5")
-	infoResults := make([]params.ModelInfoResult, len(models))
-	for i, model := range models {
-		infoResult := params.ModelInfoResult{}
-		infoResult.Result = &params.ModelInfo{
-			Name:         model.Name,
-			UUID:         model.UUID,
-			OwnerTag:     names.NewUserTag(model.Owner).String(),
-			CloudTag:     "cloud-dummy",
-			AgentVersion: &agentVersion,
-			Status:       params.EntityStatus{Status: status.Active},
-		}
-		infoResults[i] = infoResult
-	}
-	return infoResults
-}
-
-func (s *ModelsSuiteV4) SetUpTest(c *gc.C) {
-	s.ModelsSuite.SetUpTest(c)
-	// re-run all the test for ModelManager v4
-	s.ModelsSuite.api.version = 4
 }

--- a/cmd/juju/controller/listmodelsold.go
+++ b/cmd/juju/controller/listmodelsold.go
@@ -1,0 +1,231 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/jujuclient"
+)
+
+// oldModelsCommandBehaviour is the 'models' behavior for pre Juju 2.3.
+// This call:
+// * gets all possible models (api calls)
+// * translates them into user-friendly representation (presentation layer)
+// * stores retrieved models in client store
+// * identifies current model
+// Call returns whether any models hav been found and any errors.
+func (c *modelsCommand) oldModelsCommandBehaviour(
+	ctx *cmd.Context,
+	modelmanagerAPI ModelManagerAPI,
+	now time.Time,
+) (bool, error) {
+	var models []base.UserModel
+	var err error
+	if c.all {
+		models, err = c.getAllModels()
+	} else {
+		models, err = c.getUserModels(modelmanagerAPI)
+	}
+	if err != nil {
+		return false, errors.Annotate(err, "cannot list models")
+	}
+	modelInfo, modelsToStore, err := c.getModelInfo(modelmanagerAPI, now, models)
+	if err != nil {
+		return false, errors.Annotate(err, "cannot get model details")
+	}
+	found := len(modelInfo) == 0
+
+	if err := c.ClientStore().SetModels(c.runVars.controllerName, modelsToStore); err != nil {
+		return found, errors.Trace(err)
+	}
+
+	// Identifying current model has to be done after models in client store have been updated
+	// since that call determines/updates current model information.
+	modelSet := ModelSet{Models: modelInfo}
+	modelSet.CurrentModelQualified, modelSet.CurrentModel = c.currentModelName()
+	if err := c.out.Write(ctx, modelSet); err != nil {
+		return found, err
+	}
+	return found, err
+}
+
+// (anastasiamac 2017-23-11) This is old, pre juju 2.3 implementation.
+func (c *modelsCommand) getModelInfo(
+	client ModelManagerAPI,
+	now time.Time,
+	userModels []base.UserModel,
+) ([]common.ModelInfo, map[string]jujuclient.ModelDetails, error) {
+	tags := make([]names.ModelTag, len(userModels))
+	for i, m := range userModels {
+		tags[i] = names.NewModelTag(m.UUID)
+	}
+	results, err := client.ModelInfo(tags)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	info := []common.ModelInfo{}
+	modelsToStore := map[string]jujuclient.ModelDetails{}
+	for i, result := range results {
+		if result.Error != nil {
+			if params.IsCodeUnauthorized(result.Error) {
+				// If we get this, then the model was removed
+				// between the initial listing and the call
+				// to query its details.
+				continue
+			}
+			return nil, nil, errors.Annotatef(
+				result.Error, "getting model %s (%q) info",
+				userModels[i].UUID, userModels[i].Name,
+			)
+		}
+
+		model, err := common.ModelInfoFromParams(*result.Result, now)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		model.ControllerName = c.runVars.controllerName
+		info = append(info, model)
+		modelsToStore[model.Name] = jujuclient.ModelDetails{model.UUID}
+
+		if len(model.Machines) != 0 {
+			c.runVars.hasMachinesCount = true
+			for _, m := range model.Machines {
+				if m.Cores != 0 {
+					c.runVars.hasCoresCount = true
+					break
+				}
+			}
+		}
+	}
+	return info, modelsToStore, nil
+}
+
+func (c *modelsCommand) getAllModels() ([]base.UserModel, error) {
+	client, err := c.getSysAPI()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer client.Close()
+	return client.AllModels()
+}
+
+// ModelsSysAPI defines the methods on the controller manager API that the
+// list models command calls.
+type ModelsSysAPI interface {
+	Close() error
+	AllModels() ([]base.UserModel, error)
+}
+
+func (c *modelsCommand) getSysAPI() (ModelsSysAPI, error) {
+	if c.sysAPI != nil {
+		return c.sysAPI, nil
+	}
+	return c.NewControllerAPIClient()
+}
+
+func (c *modelsCommand) getUserModels(client ModelManagerAPI) ([]base.UserModel, error) {
+	return client.ListModels(c.user)
+}
+
+// ModelSet contains the set of models known to the client,
+// and UUID of the current model.
+// (anastasiamac 2017-23-11) This is old, pre juju 2.3 implementation.
+type ModelSet struct {
+	Models []common.ModelInfo `yaml:"models" json:"models"`
+
+	// CurrentModel is the name of the current model, qualified for the
+	// user for which we're listing models. i.e. for the user admin,
+	// and the model admin/foo, this field will contain "foo"; for
+	// bob and the same model, the field will contain "admin/foo".
+	CurrentModel string `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+
+	// CurrentModelQualified is the fully qualified name for the current
+	// model, i.e. having the format $owner/$model.
+	CurrentModelQualified string `yaml:"-" json:"-"`
+}
+
+// formatTabular takes a model set to adhere to the cmd.Formatter interface
+// (anastasiamac 2017-23-11) This is old, pre juju 2.3 implementation.
+func (c *modelsCommand) tabularSet(writer io.Writer, modelSet ModelSet) error {
+	// We need the tag of the user for which we're listing models,
+	// and for the logged-in user. We use these below when formatting
+	// the model display names.
+	loggedInUser := names.NewUserTag(c.loggedInUser)
+	userForLastConn := loggedInUser
+	var currentUser names.UserTag
+	if c.user != "" {
+		currentUser = names.NewUserTag(c.user)
+		userForLastConn = currentUser
+	}
+
+	tw := output.TabWriter(writer)
+	w := output.Wrapper{tw}
+	c.tabularColumns(tw, w)
+
+	for _, model := range modelSet.Models {
+		cloudRegion := strings.Trim(model.Cloud+"/"+model.CloudRegion, "/")
+		owner := names.NewUserTag(model.Owner)
+		name := model.Name
+		if currentUser == owner {
+			// No need to display fully qualified model name to its owner.
+			name = model.ShortName
+		}
+		if model.Name == modelSet.CurrentModelQualified {
+			name += "*"
+			w.PrintColor(output.CurrentHighlight, name)
+		} else {
+			w.Print(name)
+		}
+		if c.listUUID {
+			w.Print(model.UUID)
+		}
+		userForAccess := loggedInUser
+		if c.user != "" {
+			userForAccess = names.NewUserTag(c.user)
+		}
+		status := "-"
+		if model.Status != nil {
+			status = model.Status.Current.String()
+		}
+		w.Print(cloudRegion, status)
+		if c.runVars.hasMachinesCount {
+			w.Print(fmt.Sprintf("%d", len(model.Machines)))
+		}
+		if c.runVars.hasCoresCount {
+			cores := uint64(0)
+			for _, m := range model.Machines {
+				cores += m.Cores
+			}
+			coresInfo := "-"
+			if cores > 0 {
+				coresInfo = fmt.Sprintf("%d", cores)
+			}
+			w.Print(coresInfo)
+		}
+		access := model.Users[userForAccess.Id()].Access
+		if access == "" {
+			access = "-"
+		}
+		lastConnection := model.Users[userForLastConn.Id()].LastConnection
+		if lastConnection == "" {
+			lastConnection = "never connected"
+		}
+		w.Println(access, lastConnection)
+	}
+	tw.Flush()
+	return nil
+}

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -99,12 +99,14 @@ func (s *cmdControllerSuite) TestCreateModelAdminUser(c *gc.C) {
 func (s *cmdControllerSuite) TestAddModelNormalUser(c *gc.C) {
 	s.createModelNormalUser(c, "new-model", false)
 	context := s.run(c, "list-models", "--all")
+	// TODO (anastasiamac 2017-11-23) currently logged in user does not have any right to the model,
+	// except that they are a superuser on the controller?..
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: kontroll\n"+
 		"\n"+
-		"Model              Cloud/Region        Status     Access  Last connection\n"+
-		"admin/controller*  dummy/dummy-region  available  admin   just now\n"+
-		"test/new-model     dummy/dummy-region  available  -       never connected\n"+
+		"Model           Cloud/Region        Status     Access  Last connection\n"+
+		"controller*     dummy/dummy-region  available  admin   just now\n"+
+		"test/new-model  dummy/dummy-region  available  admin   never connected\n"+
 		"\n")
 }
 
@@ -128,17 +130,9 @@ models:
   status:
     current: available
     since: .*
-  users:
-    admin:
-      display-name: admin
-      access: admin
-      last-connection: just now
-  machines:
-    "0":
-      cores: 0
-    "1":
-      cores: 2
-  sla: unsupported
+  access: admin
+  last-connection: just now
+  sla-owner: admin
   agent-version: %v
 current-model: controller
 `[1:]


### PR DESCRIPTION
## Description of change

CMD:
This PR introduced new cmd-layer type for presentation that caters to correspondenly new api layer type.
Updated formatting logic to be more efficient.

API/APISERVER: 
Renamed to ListModelSummaries.
Updated returned params types and names.

UNIT TEST
All cmd/juju tests pass.
All api layer unit tests pass.
Added fuller coverage to apiserver layer.

Will come back later on tonight or tomorrow to add more cmd tests.

